### PR TITLE
update minimum requirements for six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ flask-pymongo
 tornado
 passlib
 https://github.com/marianoguerra/feedformatter/archive/master.zip
+six>=1.9.0


### PR DESCRIPTION
This solves a bug I had with older versions of six on Linux systems, where it tries to import winreg, a module only available on windows.