### PR TITLE
Small bugfix

### DIFF
--- a/sbin/db_mgmt_capec.py
+++ b/sbin/db_mgmt_capec.py
@@ -16,7 +16,7 @@ from xml.sax.handler import ContentHandler
 
 from lib.ProgressBar import progressbar
 from lib.Config import Configuration
-
+import lib.DatabaseLayer as dbLayer
 
 class CapecHandler(ContentHandler):
     def __init__(self):


### PR DESCRIPTION
This fixes:

Starting capec
Traceback (most recent call last):
  File "/home/laurens/Source/cve-search/sbin/db_mgmt_capec.py", line 172, in <module>
    i = dbLayer.getLastModified('capec')
NameError: name 'dbLayer' is not defined
capec has 463 elements (0 update)

When doing '''python3 ./db_updater.py -c -i -v'''